### PR TITLE
[#24] 이미지 등록 기능 추가, AWS S3 서비스 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,10 @@ dependencies {
     // health check
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+    // file
+    implementation("software.amazon.awssdk:s3:2.20.52")
+    implementation("software.amazon.awssdk:sts:2.20.52")
+
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/java/com/bgaebalja/blogbackend/config/S3Config.java
+++ b/src/main/java/com/bgaebalja/blogbackend/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.bgaebalja.blogbackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/controller/ImageController.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/controller/ImageController.java
@@ -1,0 +1,36 @@
+package com.bgaebalja.blogbackend.image.controller;
+
+import com.bgaebalja.blogbackend.image.domain.AddImageRequest;
+import com.bgaebalja.blogbackend.image.domain.GetImageResponse;
+import com.bgaebalja.blogbackend.image.domain.Image;
+import com.bgaebalja.blogbackend.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@Controller
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageService imageService;
+
+    private static final String ADD_IMAGE = "이미지 추가";
+    private static final String ADD_IMAGE_DESCRIPTION = "이미지와 대상 타입, 대상 ID를 입력해 이미지를 추가할 수 있습니다.";
+    private static final String ADD_IMAGE_FORM = "이미지 추가 양식";
+
+    @Operation(summary = ADD_IMAGE, description = ADD_IMAGE_DESCRIPTION)
+    @PostMapping()
+    public ResponseEntity<GetImageResponse> addImage(
+            @ModelAttribute @Parameter(description = ADD_IMAGE_FORM) AddImageRequest addImageRequest
+    ) {
+        Image image = imageService.createImage(addImageRequest);
+        return ResponseEntity.status(CREATED).body(GetImageResponse.from(image));
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/domain/AddImageRequest.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/domain/AddImageRequest.java
@@ -1,0 +1,30 @@
+package com.bgaebalja.blogbackend.image.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.bgaebalja.blogbackend.util.ApiConstant.ID_EXAMPLE;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class AddImageRequest {
+    private static final String IMAGE_VALUE = "이미지";
+
+    private static final String TARGET_TYPE_VALUE = "대상 타입";
+    private static final String TARGET_TYPE_EXAMPLE = "POST";
+
+    private static final String TARGET_ID_VALUE = "대상 ID";
+
+    @Schema(description = IMAGE_VALUE)
+    private MultipartFile image;
+
+    @Schema(description = TARGET_TYPE_VALUE, example = TARGET_TYPE_EXAMPLE)
+    private String targetType;
+
+    @Schema(description = TARGET_ID_VALUE, example = ID_EXAMPLE)
+    private String targetId;
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/domain/GetImageResponse.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/domain/GetImageResponse.java
@@ -1,0 +1,18 @@
+package com.bgaebalja.blogbackend.image.domain;
+
+import lombok.Getter;
+
+@Getter
+public class GetImageResponse {
+    private Long id;
+    private String url;
+
+    private GetImageResponse(Long id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+
+    public static GetImageResponse from(Image image) {
+        return new GetImageResponse(image.getId(), image.getS3Url());
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/domain/Image.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/domain/Image.java
@@ -1,0 +1,43 @@
+package com.bgaebalja.blogbackend.image.domain;
+
+import com.bgaebalja.blogbackend.audit.BaseGeneralEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.NoArgsConstructor;
+
+import static com.bgaebalja.blogbackend.util.EntityConstant.BOOLEAN_DEFAULT_FALSE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Image extends BaseGeneralEntity {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(name = "s3_url", nullable = false, length = 500)
+    private String s3Url;
+
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean representativeYn;
+
+    private Image(TargetType targetType, Long targetId, String s3Url, boolean isRepresentative) {
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.s3Url = s3Url;
+        representativeYn = isRepresentative;
+    }
+
+    public static Image of(TargetType targetType, Long targetId, String s3Url, boolean isRepresentative) {
+        return new Image(targetType, targetId, s3Url, isRepresentative);
+    }
+
+    public String getS3Url() {
+        return s3Url;
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/domain/TargetType.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/domain/TargetType.java
@@ -1,0 +1,15 @@
+package com.bgaebalja.blogbackend.image.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TargetType {
+    MEMBER("회원"),
+    POST("게시글"),
+    COMMENT("댓글"),
+    ALARM("알림");
+
+    private final String description;
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/exception/ExceptionMessage.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/exception/ExceptionMessage.java
@@ -1,0 +1,9 @@
+package com.bgaebalja.blogbackend.image.exception;
+
+public class ExceptionMessage {
+    public static final String S3_UPLOAD_FAILED_EXCEPTION_MESSAGE = "S3 업로드 과정에서 오류가 발생했습니다.";
+    public static final String IMAGE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 이미지를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 ID: %d";
+    public static final String TARGET_IMAGE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 이미지를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 대상 타입: %s, 전송된 대상 ID: %d";
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/exception/ImageNotFoundException.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/exception/ImageNotFoundException.java
@@ -1,0 +1,9 @@
+package com.bgaebalja.blogbackend.image.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class ImageNotFoundException extends EntityNotFoundException {
+    public ImageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/exception/S3UploadFailedException.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/exception/S3UploadFailedException.java
@@ -1,0 +1,7 @@
+package com.bgaebalja.blogbackend.image.exception;
+
+public class S3UploadFailedException extends RuntimeException {
+    public S3UploadFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/repository/ImageRepository.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/repository/ImageRepository.java
@@ -1,0 +1,27 @@
+package com.bgaebalja.blogbackend.image.repository;
+
+import com.bgaebalja.blogbackend.image.domain.Image;
+import com.bgaebalja.blogbackend.image.domain.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findByTargetTypeAndTargetIdAndDeleteYnFalse(TargetType targetType, Long id);
+
+    Optional<Image> findByIdAndDeleteYnFalse(Long id);
+
+    Optional<Image> findByTargetTypeAndTargetIdAndRepresentativeYnTrueAndDeleteYnFalse(
+            TargetType targetType, Long targetId
+    );
+
+    Optional<Image> findFirstByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAt(
+            TargetType targetType, Long targetId
+    );
+
+    Optional<Image> findByRepresentativeYnTrueAndDeleteYnFalse();
+
+    // 추후 삭제
+    List<Image> findByTargetId(Long targetId);
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/service/ImageService.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/service/ImageService.java
@@ -1,0 +1,13 @@
+package com.bgaebalja.blogbackend.image.service;
+
+import com.bgaebalja.blogbackend.image.domain.AddImageRequest;
+import com.bgaebalja.blogbackend.image.domain.Image;
+import com.bgaebalja.blogbackend.image.domain.TargetType;
+
+import java.util.List;
+
+public interface ImageService {
+    Image createImage(AddImageRequest addImageRequest);
+
+    List<Image> getImages(TargetType targetType, Long targetId);
+}

--- a/src/main/java/com/bgaebalja/blogbackend/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bgaebalja/blogbackend/image/service/ImageServiceImpl.java
@@ -1,0 +1,111 @@
+package com.bgaebalja.blogbackend.image.service;
+
+import com.bgaebalja.blogbackend.image.domain.AddImageRequest;
+import com.bgaebalja.blogbackend.image.domain.Image;
+import com.bgaebalja.blogbackend.image.domain.TargetType;
+import com.bgaebalja.blogbackend.image.exception.ImageNotFoundException;
+import com.bgaebalja.blogbackend.image.exception.S3UploadFailedException;
+import com.bgaebalja.blogbackend.image.repository.ImageRepository;
+import com.bgaebalja.blogbackend.util.FormatConverter;
+import com.bgaebalja.blogbackend.util.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static com.bgaebalja.blogbackend.image.exception.ExceptionMessage.IMAGE_NOT_FOUND_EXCEPTION_MESSAGE;
+import static com.bgaebalja.blogbackend.image.exception.ExceptionMessage.S3_UPLOAD_FAILED_EXCEPTION_MESSAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+    private final ImageRepository imageRepository;
+    private final S3Client s3Client;
+
+    private static final String TLS_HTTP_PROTOCOL = "https://";
+    private static final String S3_ADDRESS = "s3.amazonaws.com";
+    private static final String CACHE_VALUE = "images";
+
+    private static final String CREATE_IMAGE_KEY = "#addImagesRequest.targetId";
+    private static final String CREATE_KEY_CONDITION = "#addImagesRequest != null && #addImagesRequest.targetId != null";
+
+    private static final String GET_IMAGE_KEY = "#targetId";
+    private static final String GET_KEY_CONDITION = "#targetId != null";
+
+    private static final String DELETE_IMAGE_KEY = "#id";
+    private static final String DELETE_KEY_CONDITION = "#id != null";
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String s3BucketName;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 10)
+    @CachePut(key = CREATE_IMAGE_KEY, condition = CREATE_KEY_CONDITION, value = CACHE_VALUE)
+    public Image createImage(AddImageRequest addImageRequest) {
+        MultipartFile imageToUpload = addImageRequest.getImage();
+        TargetType targetType = FormatConverter.parseToTargetType(addImageRequest.getTargetType());
+        Long targetId = FormatConverter.parseToLong(addImageRequest.getTargetId());
+
+        List<Image> existingImages = imageRepository.findByTargetTypeAndTargetIdAndDeleteYnFalse(targetType, targetId);
+        boolean isRepresentativeImageExistent = FormatValidator.hasValue(existingImages);
+        Image image = Image.of(
+                targetType, targetId, uploadToS3(imageToUpload, targetType, targetId), !isRepresentativeImageExistent
+        );
+        imageRepository.save(image);
+
+        return image;
+    }
+
+    private String uploadToS3(MultipartFile image, TargetType targetType, Long productId) {
+        String sanitizedFilename = FormatConverter.sanitizeFileName(image.getOriginalFilename());
+        long ms = System.currentTimeMillis();
+        String key
+                = String.format("%s/%d/%s_%s", targetType.toString().toLowerCase(), productId, ms, sanitizedFilename);
+
+        try {
+            File tempFile = convertMultipartFileToFile(image);
+            s3Client.putObject(PutObjectRequest.builder()
+                    .bucket(s3BucketName)
+                    .key(key)
+                    .build(), Paths.get(tempFile.getPath()));
+            tempFile.delete();
+        } catch (IOException ie) {
+            throw new S3UploadFailedException(S3_UPLOAD_FAILED_EXCEPTION_MESSAGE, ie);
+        }
+
+        return String.format("%s%s.%s/%s", TLS_HTTP_PROTOCOL, s3BucketName, S3_ADDRESS, key);
+    }
+
+    private File convertMultipartFileToFile(MultipartFile image) throws IOException {
+        File convertedFile
+                = new File(String.format("%s/%s", System.getProperty("java.io.tmpdir"), image.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(image.getBytes());
+        }
+        return convertedFile;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
+    @Cacheable(key = GET_IMAGE_KEY, condition = GET_KEY_CONDITION, value = CACHE_VALUE)
+    public List<Image> getImages(TargetType targetType, Long targetId) {
+        return imageRepository.findByTargetTypeAndTargetIdAndDeleteYnFalse(targetType, targetId);
+    }
+
+    private Image getImage(Long id) {
+        return imageRepository.findByIdAndDeleteYnFalse(id)
+                .orElseThrow(() -> new ImageNotFoundException(String.format(IMAGE_NOT_FOUND_EXCEPTION_MESSAGE, id)));
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/util/ApiConstant.java
+++ b/src/main/java/com/bgaebalja/blogbackend/util/ApiConstant.java
@@ -3,6 +3,7 @@ package com.bgaebalja.blogbackend.util;
 public class ApiConstant {
     public static final String USER_EMAIL_VALUE = "회원 이메일";
     public static final String EMAIL_EXAMPLE = "tester1@example.com";
+    public static final String ID_EXAMPLE = "1";
     public static final String USER_FULLNAME_VALUE = "회원 카카오톡 닉네임";
     public static final String FULLNAME_EXAMPLE = "홍길동";
     public static final String USER_NAME_VALUE = "B-LOG에서 사용할 닉네임";

--- a/src/main/java/com/bgaebalja/blogbackend/util/FormatConverter.java
+++ b/src/main/java/com/bgaebalja/blogbackend/util/FormatConverter.java
@@ -1,0 +1,31 @@
+package com.bgaebalja.blogbackend.util;
+
+import com.bgaebalja.blogbackend.exception.InvalidTargetTypeException;
+import com.bgaebalja.blogbackend.exception.ParsingLongException;
+import com.bgaebalja.blogbackend.image.domain.TargetType;
+
+import static com.bgaebalja.blogbackend.exception.ExceptionMessage.INVALID_TARGET_TYPE_EXCEPTION_MESSAGE;
+import static com.bgaebalja.blogbackend.exception.ExceptionMessage.PARSING_LONG_EXCEPTION_MESSAGE;
+
+public class FormatConverter {
+    public static long parseToLong(String number) {
+        try {
+            return Long.parseLong(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingLongException((String.format(PARSING_LONG_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
+    public static TargetType parseToTargetType(String targetType) {
+        try {
+            return TargetType.valueOf(targetType);
+        } catch (IllegalArgumentException iae) {
+            throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
+        }
+    }
+
+    public static String sanitizeFileName(String filename) {
+        return filename.replaceAll("\\s+", "-")
+                .replaceAll("[^a-zA-Z0-9._-]", "");
+    }
+}

--- a/src/main/java/com/bgaebalja/blogbackend/util/FormatValidator.java
+++ b/src/main/java/com/bgaebalja/blogbackend/util/FormatValidator.java
@@ -5,6 +5,8 @@ import com.bgaebalja.blogbackend.exception.IdNoValueException;
 import com.bgaebalja.blogbackend.exception.InvalidEmailException;
 import com.bgaebalja.blogbackend.exception.InvalidIdException;
 
+import java.util.List;
+
 import static com.bgaebalja.blogbackend.exception.ExceptionMessage.*;
 import static com.bgaebalja.blogbackend.util.RegularExpressionConstant.EMAIL_PATTERN;
 import static com.bgaebalja.blogbackend.util.RegularExpressionConstant.POSITIVE_INTEGER_PATTERN;
@@ -14,25 +16,26 @@ public class FormatValidator {
         if (!hasValue(email)) {
             throw new EmailNoValueException(EMAIL_NO_VALUE_EXCEPTION_MESSAGE);
         }
-        ;
         if (!isValid(email, EMAIL_PATTERN)) {
-            throw new InvalidEmailException(INVALID_EMAIL_EXCEPTION_MESSAGE + email);
+            throw new InvalidEmailException(String.format(INVALID_EMAIL_EXCEPTION_MESSAGE + email));
         }
-        ;
     }
 
     public static void validateId(String id) {
         if (!hasValue(id)) {
             throw new IdNoValueException(ID_NO_VALUE_EXCEPTION_MESSAGE);
         }
-        ;
         if (!isValid(id, POSITIVE_INTEGER_PATTERN)) {
-            throw new InvalidIdException(INVALID_ID_EXCEPTION_MESSAGE + id);
+            throw new InvalidIdException(String.format(INVALID_ID_EXCEPTION_MESSAGE, id));
         }
     }
 
     public static boolean hasValue(String value) {
         return value != null && !value.isBlank();
+    }
+
+    public static boolean hasValue(List value) {
+        return value != null && !value.isEmpty();
     }
 
     private static boolean isValid(String value, String pattern) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,15 @@ spring:
           format_sql: true
 logging:
   config: classpath:logback-spring.xml
+cloud:
+  aws:
+    credentials:
+      access-key: ${B_LOG_S3_ACCESS_KEY}
+      secret-key: ${B_LOG_S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket-name: ${B_LOG_S3_BUCKET_NAME}
+jwt:
+  secret:
+    key: ${B_LOG_JWT_SECRET_KEY}


### PR DESCRIPTION
## resolve #24

## 추가사항
- AWS S3 의존성
- AWS STS 의존성
- S3Config 클래스
- AWS Access key
- AWS Secret key
- AWS 지역 설정
- AWS S3 버킷 이름
- 이미지 저장 요청
- 이미지 저장 비즈니스 로직
- AWS S3에 이미지 데이터 저장
- 이미지 데이터 저장 실패 시 예외 처리
- 데이터베이스에 대상 도메인 타입, 대상 ID, S3 URL 저장
- 201 status code 반환

## 배포
- [x] 확인